### PR TITLE
feat: OTP後伺服器選擇功能

### DIFF
--- a/ROZeroLoginer/MainWindow.xaml.cs
+++ b/ROZeroLoginer/MainWindow.xaml.cs
@@ -267,7 +267,7 @@ namespace ROZeroLoginer
                 var inputService = new InputService();
                 var settings = _dataService.GetSettings();
 
-                inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, skipAgreeButton);
+                inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, skipAgreeButton, 0, account.Server);
 
                 _dataService.UpdateAccountLastUsed(account.Id);
 
@@ -868,7 +868,7 @@ namespace ROZeroLoginer
                 {
                     LogService.Instance.Info("[BatchLaunch] 在主線程中開始執行輸入操作 - {0}", account.Username);
                     var inputService = new InputService();
-                    inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, false, gameProcess.Id);
+                    inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, false, gameProcess.Id, account.Server);
                     LogService.Instance.Info("[BatchLaunch] 輸入操作完成 - {0}", account.Username);
                 }
                 catch (Exception ex)

--- a/ROZeroLoginer/Models/Account.cs
+++ b/ROZeroLoginer/Models/Account.cs
@@ -12,6 +12,7 @@ namespace ROZeroLoginer.Models
         private string _password;
         private string _otpSecret;
         private string _group;
+        private int _server = 1;
         private DateTime _createdAt;
         private DateTime _lastUsed;
 
@@ -75,6 +76,16 @@ namespace ROZeroLoginer.Models
             }
         }
 
+        public int Server
+        {
+            get => _server;
+            set
+            {
+                _server = value;
+                OnPropertyChanged();
+            }
+        }
+
         public DateTime CreatedAt
         {
             get => _createdAt;
@@ -102,12 +113,13 @@ namespace ROZeroLoginer.Models
             LastUsed = DateTime.MinValue;
         }
 
-        public Account(string name, string username, string password, string otpSecret, string group = "預設") : this()
+        public Account(string name, string username, string password, string otpSecret, int server = 1, string group = "預設") : this()
         {
             Name = name;
             Username = username;
             Password = password;
             OtpSecret = otpSecret;
+            Server = server;
             Group = group;
         }
 

--- a/ROZeroLoginer/Services/DataService.cs
+++ b/ROZeroLoginer/Services/DataService.cs
@@ -51,6 +51,7 @@ namespace ROZeroLoginer.Services
                 existingAccount.Username = account.Username;
                 existingAccount.Password = account.Password;
                 existingAccount.OtpSecret = account.OtpSecret;
+                existingAccount.Server = account.Server;
             }
             else
             {

--- a/ROZeroLoginer/Services/InputService.cs
+++ b/ROZeroLoginer/Services/InputService.cs
@@ -290,7 +290,7 @@ namespace ROZeroLoginer.Services
             public int Bottom;
         }
 
-        public void SendLogin(string username, string password, string otpSecret, int otpDelayMs = 2000, AppSettings settings = null, bool skipAgreeButton = false, int targetProcessId = 0)
+        public void SendLogin(string username, string password, string otpSecret, int otpDelayMs = 2000, AppSettings settings = null, bool skipAgreeButton = false, int targetProcessId = 0, int server = 1)
         {
             LogService.Instance.Info("[SendLogin] 開始登入流程 - 用戶: {0}, 跳過同意按鈕: {1}, 目標PID: {2}", username, skipAgreeButton, targetProcessId);
 
@@ -419,6 +419,14 @@ namespace ROZeroLoginer.Services
             Thread.Sleep(100);
 
             // 檢查視窗焦點並按下 ENTER 鍵
+            CheckRagnarokWindowFocus(targetProcessId);
+            SendKey(Keys.Enter);
+
+            // 選擇伺服器
+            Thread.Sleep(500);
+            CheckRagnarokWindowFocus(targetProcessId);
+            SendText(server.ToString());
+            Thread.Sleep(100);
             CheckRagnarokWindowFocus(targetProcessId);
             SendKey(Keys.Enter);
 

--- a/ROZeroLoginer/Windows/AccountWindow.xaml
+++ b/ROZeroLoginer/Windows/AccountWindow.xaml
@@ -13,6 +13,8 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -29,7 +31,13 @@
         <TextBlock Grid.Row="6" Text="分組:" FontWeight="Bold" Margin="0,5"/>
         <ComboBox Grid.Row="7" Name="GroupComboBox" Margin="0,5" Height="25" IsEditable="True" Style="{StaticResource ModernComboBoxStyle}"/>
 
-        <GroupBox Grid.Row="8" Header="OTP Secret Key" Margin="0,10">
+        <TextBlock Grid.Row="8" Text="伺服器:" FontWeight="Bold" Margin="0,5"/>
+        <ComboBox Grid.Row="9" Name="ServerComboBox" Margin="0,5" Height="25" Style="{StaticResource ModernComboBoxStyle}">
+            <ComboBoxItem Content="1號伺服器" Tag="1"/>
+            <ComboBoxItem Content="2號伺服器" Tag="2"/>
+        </ComboBox>
+
+        <GroupBox Grid.Row="10" Header="OTP Secret Key" Margin="0,10">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -53,7 +61,7 @@
             </Grid>
         </GroupBox>
 
-        <StackPanel Grid.Row="9" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+        <StackPanel Grid.Row="11" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
             <Button Name="OkButton" Content="確定" Style="{StaticResource ButtonStyle}" 
                     Width="80" Click="OkButton_Click" IsDefault="True"/>
             <Button Name="CancelButton" Content="取消" Style="{StaticResource ButtonStyle}" 

--- a/ROZeroLoginer/Windows/AccountWindow.xaml.cs
+++ b/ROZeroLoginer/Windows/AccountWindow.xaml.cs
@@ -82,6 +82,7 @@ namespace ROZeroLoginer.Windows
                 PasswordBox.Password = _account.Password ?? "";
                 OtpSecretTextBox.Text = _account.OtpSecret ?? "";
                 GroupComboBox.Text = _account.Group ?? "預設";
+                ServerComboBox.SelectedIndex = _account.Server == 2 ? 1 : 0;
             }
         }
 
@@ -129,6 +130,7 @@ namespace ROZeroLoginer.Windows
                 _account.Password = PasswordBox.Password;
                 _account.OtpSecret = OtpSecretTextBox.Text.Trim();
                 _account.Group = string.IsNullOrWhiteSpace(GroupComboBox.Text) ? "預設" : GroupComboBox.Text.Trim();
+                _account.Server = ServerComboBox.SelectedIndex == 1 ? 2 : 1;
                 
                 DialogResult = true;
                 Close();


### PR DESCRIPTION
## Summary
- 新增 Account.Server 屬性並保存於資料服務
- 於帳號設定視窗加入伺服器下拉選單
- 自動登入流程在輸入 OTP 後依照帳號設定選擇伺服器

## Testing
- `dotnet build` *(missing: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68985e8b49888333a022c166a1f023cb