### PR TITLE
feat: add auto assist battle toggle

### DIFF
--- a/ROZeroLoginer/MainWindow.xaml.cs
+++ b/ROZeroLoginer/MainWindow.xaml.cs
@@ -267,7 +267,7 @@ namespace ROZeroLoginer
                 var inputService = new InputService();
                 var settings = _dataService.GetSettings();
 
-                inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, skipAgreeButton, 0, account.Server, account.Character, account.LastCharacter);
+                inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, skipAgreeButton, 0, account.Server, account.Character, account.LastCharacter, account.AutoAssistBattle);
 
                 account.LastUsed = DateTime.Now;
                 account.LastCharacter = account.Character;
@@ -870,7 +870,7 @@ namespace ROZeroLoginer
                 {
                     LogService.Instance.Info("[BatchLaunch] 在主線程中開始執行輸入操作 - {0}", account.Username);
                     var inputService = new InputService();
-                    inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, false, gameProcess.Id, account.Server, account.Character, account.LastCharacter);
+                    inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, false, gameProcess.Id, account.Server, account.Character, account.LastCharacter, account.AutoAssistBattle);
                     LogService.Instance.Info("[BatchLaunch] 輸入操作完成 - {0}", account.Username);
                 }
                 catch (Exception ex)

--- a/ROZeroLoginer/Models/Account.cs
+++ b/ROZeroLoginer/Models/Account.cs
@@ -17,6 +17,7 @@ namespace ROZeroLoginer.Models
         private int _lastCharacter = 1;
         private DateTime _createdAt;
         private DateTime _lastUsed;
+        private bool _autoAssistBattle;
 
         public string Id
         {
@@ -124,6 +125,16 @@ namespace ROZeroLoginer.Models
             set
             {
                 _lastUsed = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool AutoAssistBattle
+        {
+            get => _autoAssistBattle;
+            set
+            {
+                _autoAssistBattle = value;
                 OnPropertyChanged();
             }
         }

--- a/ROZeroLoginer/Services/DataService.cs
+++ b/ROZeroLoginer/Services/DataService.cs
@@ -54,6 +54,7 @@ namespace ROZeroLoginer.Services
                 existingAccount.Server = account.Server;
                 existingAccount.Character = account.Character;
                 existingAccount.LastCharacter = account.LastCharacter;
+                existingAccount.AutoAssistBattle = account.AutoAssistBattle;
                 existingAccount.LastUsed = account.LastUsed;
             }
             else

--- a/ROZeroLoginer/Services/InputService.cs
+++ b/ROZeroLoginer/Services/InputService.cs
@@ -290,7 +290,7 @@ namespace ROZeroLoginer.Services
             public int Bottom;
         }
 
-        public void SendLogin(string username, string password, string otpSecret, int otpDelayMs = 2000, AppSettings settings = null, bool skipAgreeButton = false, int targetProcessId = 0, int server = 1, int character = 1, int lastCharacter = 1)
+        public void SendLogin(string username, string password, string otpSecret, int otpDelayMs = 2000, AppSettings settings = null, bool skipAgreeButton = false, int targetProcessId = 0, int server = 1, int character = 1, int lastCharacter = 1, bool autoAssistBattle = false)
         {
             LogService.Instance.Info("[SendLogin] 開始登入流程 - 用戶: {0}, 跳過同意按鈕: {1}, 目標PID: {2}", username, skipAgreeButton, targetProcessId);
 
@@ -468,6 +468,13 @@ namespace ROZeroLoginer.Services
             }
 
             SendKey(Keys.Enter);
+
+            if (autoAssistBattle)
+            {
+                Thread.Sleep(500);
+                CheckRagnarokWindowFocus(targetProcessId);
+                SendKeyCombo(new[] { Keys.Menu, Keys.Oemplus });
+            }
 
             // 標記視窗為已登入，避免重複使用
             MarkWindowAsLoggedIn(targetWindow);

--- a/ROZeroLoginer/Windows/AccountWindow.xaml
+++ b/ROZeroLoginer/Windows/AccountWindow.xaml
@@ -17,6 +17,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -48,7 +49,9 @@
             <ComboBoxItem Content="5" Tag="5"/>
         </ComboBox>
 
-        <GroupBox Grid.Row="12" Header="OTP Secret Key" Margin="0,10">
+        <CheckBox Grid.Row="12" Name="AutoAssistCheckBox" Content="自動開啟輔助戰鬥" Margin="0,5"/>
+
+        <GroupBox Grid.Row="13" Header="OTP Secret Key" Margin="0,10">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -72,7 +75,7 @@
             </Grid>
         </GroupBox>
 
-        <StackPanel Grid.Row="13" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+        <StackPanel Grid.Row="14" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
             <Button Name="OkButton" Content="確定" Style="{StaticResource ButtonStyle}" 
                     Width="80" Click="OkButton_Click" IsDefault="True"/>
             <Button Name="CancelButton" Content="取消" Style="{StaticResource ButtonStyle}" 

--- a/ROZeroLoginer/Windows/AccountWindow.xaml.cs
+++ b/ROZeroLoginer/Windows/AccountWindow.xaml.cs
@@ -89,6 +89,8 @@ namespace ROZeroLoginer.Windows
                     _account.Character >= 1 && _account.Character <= 5
                         ? _account.Character - 1
                         : 0;
+
+                AutoAssistCheckBox.IsChecked = _account.AutoAssistBattle;
             }
         }
 
@@ -141,7 +143,9 @@ namespace ROZeroLoginer.Windows
                 _account.Character = CharacterComboBox.SelectedIndex >= 0
                     ? CharacterComboBox.SelectedIndex + 1
                     : 1;
-                
+
+                _account.AutoAssistBattle = AutoAssistCheckBox.IsChecked == true;
+
                 DialogResult = true;
                 Close();
             }


### PR DESCRIPTION
## Summary
- add AutoAssistBattle field to account and persist it
- allow SendLogin to trigger Alt+= after character selection
- expose AutoAssistBattle toggle in account edit window

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68987363699c833395f3e9aeb32c96d7