### PR TITLE
移除自動開啟輔助戰鬥設定

### DIFF
--- a/ROZeroLoginer/MainWindow.xaml.cs
+++ b/ROZeroLoginer/MainWindow.xaml.cs
@@ -267,7 +267,7 @@ namespace ROZeroLoginer
                 var inputService = new InputService();
                 var settings = _dataService.GetSettings();
 
-                inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, skipAgreeButton, 0, account.Server, account.Character, account.LastCharacter, account.AutoAssistBattle, account.AutoAssistDelayMs);
+                inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, skipAgreeButton, 0, account.Server, account.Character, account.LastCharacter);
 
                 account.LastUsed = DateTime.Now;
                 account.LastCharacter = account.Character;
@@ -870,7 +870,7 @@ namespace ROZeroLoginer
                 {
                     LogService.Instance.Info("[BatchLaunch] 在主線程中開始執行輸入操作 - {0}", account.Username);
                     var inputService = new InputService();
-                    inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, false, gameProcess.Id, account.Server, account.Character, account.LastCharacter, account.AutoAssistBattle, account.AutoAssistDelayMs);
+                    inputService.SendLogin(account.Username, account.Password, account.OtpSecret, settings.OtpInputDelayMs, settings, false, gameProcess.Id, account.Server, account.Character, account.LastCharacter);
                     LogService.Instance.Info("[BatchLaunch] 輸入操作完成 - {0}", account.Username);
                 }
                 catch (Exception ex)

--- a/ROZeroLoginer/Models/Account.cs
+++ b/ROZeroLoginer/Models/Account.cs
@@ -17,8 +17,6 @@ namespace ROZeroLoginer.Models
         private int _lastCharacter = 1;
         private DateTime _createdAt;
         private DateTime _lastUsed;
-        private bool _autoAssistBattle;
-        private int _autoAssistDelayMs;
 
         public string Id
         {
@@ -126,26 +124,6 @@ namespace ROZeroLoginer.Models
             set
             {
                 _lastUsed = value;
-                OnPropertyChanged();
-            }
-        }
-
-        public bool AutoAssistBattle
-        {
-            get => _autoAssistBattle;
-            set
-            {
-                _autoAssistBattle = value;
-                OnPropertyChanged();
-            }
-        }
-
-        public int AutoAssistDelayMs
-        {
-            get => _autoAssistDelayMs;
-            set
-            {
-                _autoAssistDelayMs = value;
                 OnPropertyChanged();
             }
         }

--- a/ROZeroLoginer/Services/DataService.cs
+++ b/ROZeroLoginer/Services/DataService.cs
@@ -54,8 +54,6 @@ namespace ROZeroLoginer.Services
                 existingAccount.Server = account.Server;
                 existingAccount.Character = account.Character;
                 existingAccount.LastCharacter = account.LastCharacter;
-                existingAccount.AutoAssistBattle = account.AutoAssistBattle;
-                existingAccount.AutoAssistDelayMs = account.AutoAssistDelayMs;
                 existingAccount.LastUsed = account.LastUsed;
             }
             else

--- a/ROZeroLoginer/Services/InputService.cs
+++ b/ROZeroLoginer/Services/InputService.cs
@@ -290,7 +290,7 @@ namespace ROZeroLoginer.Services
             public int Bottom;
         }
 
-        public void SendLogin(string username, string password, string otpSecret, int otpDelayMs = 2000, AppSettings settings = null, bool skipAgreeButton = false, int targetProcessId = 0, int server = 1, int character = 1, int lastCharacter = 1, bool autoAssistBattle = false, int autoAssistDelayMs = 0)
+        public void SendLogin(string username, string password, string otpSecret, int otpDelayMs = 2000, AppSettings settings = null, bool skipAgreeButton = false, int targetProcessId = 0, int server = 1, int character = 1, int lastCharacter = 1)
         {
             LogService.Instance.Info("[SendLogin] 開始登入流程 - 用戶: {0}, 跳過同意按鈕: {1}, 目標PID: {2}", username, skipAgreeButton, targetProcessId);
 
@@ -468,15 +468,6 @@ namespace ROZeroLoginer.Services
             }
 
             SendKey(Keys.Enter);
-
-            if (autoAssistBattle)
-            {
-                Thread.Sleep(500 + autoAssistDelayMs);
-                CheckRagnarokWindowFocus(targetProcessId);
-                // 快捷鍵 x
-                SendKey(Keys.X);
-                LogService.Instance.Info("[SendLogin] 於 {0:HH:mm:ss.fff} 送出自動輔助戰鬥快捷鍵 X", DateTime.Now);
-            }
 
             // 標記視窗為已登入，避免重複使用
             MarkWindowAsLoggedIn(targetWindow);

--- a/ROZeroLoginer/Windows/AccountWindow.xaml
+++ b/ROZeroLoginer/Windows/AccountWindow.xaml
@@ -17,7 +17,6 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
@@ -49,13 +48,7 @@
             <ComboBoxItem Content="5" Tag="5"/>
         </ComboBox>
 
-        <StackPanel Grid.Row="12" Orientation="Horizontal" Margin="0,5">
-            <CheckBox Name="AutoAssistCheckBox" Content="自動開啟輔助戰鬥" VerticalAlignment="Center"/>
-            <TextBlock Text="延遲(秒):" Margin="10,0,0,0" VerticalAlignment="Center"/>
-            <TextBox Name="AutoAssistDelayTextBox" Width="50" Margin="5,0,0,0" Text="0"/>
-        </StackPanel>
-
-        <GroupBox Grid.Row="13" Header="OTP Secret Key" Margin="0,10">
+        <GroupBox Grid.Row="12" Header="OTP Secret Key" Margin="0,10">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -79,7 +72,7 @@
             </Grid>
         </GroupBox>
 
-        <StackPanel Grid.Row="14" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
+        <StackPanel Grid.Row="13" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,20,0,0">
             <Button Name="OkButton" Content="確定" Style="{StaticResource ButtonStyle}" 
                     Width="80" Click="OkButton_Click" IsDefault="True"/>
             <Button Name="CancelButton" Content="取消" Style="{StaticResource ButtonStyle}" 

--- a/ROZeroLoginer/Windows/AccountWindow.xaml.cs
+++ b/ROZeroLoginer/Windows/AccountWindow.xaml.cs
@@ -89,9 +89,6 @@ namespace ROZeroLoginer.Windows
                     _account.Character >= 1 && _account.Character <= 5
                         ? _account.Character - 1
                         : 0;
-
-                AutoAssistCheckBox.IsChecked = _account.AutoAssistBattle;
-                AutoAssistDelayTextBox.Text = (_account.AutoAssistDelayMs / 1000).ToString();
             }
         }
 
@@ -144,10 +141,6 @@ namespace ROZeroLoginer.Windows
                 _account.Character = CharacterComboBox.SelectedIndex >= 0
                     ? CharacterComboBox.SelectedIndex + 1
                     : 1;
-
-                _account.AutoAssistBattle = AutoAssistCheckBox.IsChecked == true;
-                int delaySec = int.TryParse(AutoAssistDelayTextBox.Text, out var ds) ? ds : 0;
-                _account.AutoAssistDelayMs = Math.Max(0, delaySec * 1000);
 
                 DialogResult = true;
                 Close();


### PR DESCRIPTION
## 摘要
- 移除帳號模型中的自動輔助戰鬥相關欄位與設定。
- 刪除登入流程中自動啟動輔助戰鬥的參數與邏輯。
- 清除帳號設定視窗與主要畫面對應的自動輔助戰鬥介面元件。

## 測試
- `dotnet build`（缺少 dotnet 指令，無法執行）
- 嘗試 `apt-get update` 安裝 dotnet 依賴，但因套件庫錯誤而失敗。


------
https://chatgpt.com/codex/tasks/task_e_68987f6357a48333adddf34c91effabc